### PR TITLE
chore: fix versions.txt for initial release

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,3 @@
-proto-google-cloud-document-ai-v1beta1:0.1.0-SNAPSHOT:0.1.0-SNAPSHOT
-grpc-google-cloud-document-ai-v1beta1:0.1.0-SNAPSHOT:0.1.0-SNAPSHOT
-google-cloud-document-ai-v1beta1:0.1.0-SNAPSHOT:0.1.0-SNAPSHOT
+proto-google-cloud-document-ai-v1beta1:0.0.0:0.0.1-SNAPSHOT
+grpc-google-cloud-document-ai-v1beta1:0.0.0:0.0.1-SNAPSHOT
+google-cloud-document-ai-v1beta1:0.0.0:0.0.1-SNAPSHOT


### PR DESCRIPTION
This will let us release 0.1.0 rather than 0.2.0