### PR TITLE
Fixed POM file links to match true Github links

### DIFF
--- a/google-cloud-document-ai-bom/pom.xml
+++ b/google-cloud-document-ai-bom/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <name>Google Cloud Document AI BOM</name>
-    <url>https://github.com/googleapis/java-documentai</url>
+    <url>https://github.com/googleapis/java-document-ai</url>
     <description>BOM for Google Cloud Document AI</description>
 
     <organization>
@@ -32,9 +32,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/googleapis/java-documentai.git</connection>
-        <developerConnection>scm:git:git@github.com:googleapis/java-documentai.git</developerConnection>
-        <url>https://github.com/googleapis/java-documentai</url>
+        <connection>scm:git:https://github.com/googleapis/java-document-ai.git</connection>
+        <developerConnection>scm:git:git@github.com:googleapis/java-document-ai.git</developerConnection>
+        <url>https://github.com/googleapis/java-document-ai</url>
     </scm>
 
     <distributionManagement>

--- a/google-cloud-document-ai/pom.xml
+++ b/google-cloud-document-ai/pom.xml
@@ -6,7 +6,7 @@
   <version>0.2.2-SNAPSHOT</version> <!-- {x-version-update:google-cloud-document-ai:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Document AI</name>
-  <url>https://github.com/googleapis/java-documentai</url>
+  <url>https://github.com/googleapis/java-document-ai</url>
   <description>Java idiomatic client for Google Cloud Document AI</description>
   <parent>
     <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <packaging>pom</packaging>
   <version>0.2.2-SNAPSHOT</version> <!-- {x-version-update:google-cloud-document-ai:current} -->
   <name>Google Cloud Document AI Parent</name>
-  <url>https://github.com/googleapis/java-documentai</url>
+  <url>https://github.com/googleapis/java-document-ai</url>
   <description>
     Java idiomatic client for Google Cloud Platform services.
   </description>
@@ -32,13 +32,13 @@
     <name>Google LLC</name>
   </organization>
   <scm>
-    <connection>scm:git:git@github.com:googleapis/java-documentai.git</connection>
-    <developerConnection>scm:git:git@github.com:googleapis/java-documentai.git</developerConnection>
-    <url>https://github.com/googleapis/java-documentai</url>
+    <connection>scm:git:git@github.com:googleapis/java-document-ai.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-document-ai.git</developerConnection>
+    <url>https://github.com/googleapis/java-document-ai</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>
-    <url>https://github.com/googleapis/java-documentai/issues</url>
+    <url>https://github.com/googleapis/java-document-ai/issues</url>
     <system>GitHub Issues</system>
   </issueManagement>
   <distributionManagement>


### PR DESCRIPTION
The true link of the Github repos used contains a dash (https://github.com/googleapis/java-document-ai/), however the libraries did originally not appear to have this.