### PR TITLE
chore: add enumeration data type to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,6 @@
     "distribution_name": "com.google.cloud:google-cloud-document-ai",
     "api_id": "documentai.googleapis.com",
     "transport": "grpc",
-    "requires_billing": true
+    "requires_billing": true,
+    "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
Adds a standard enumeration of library types in .repo-metadata.json