### PR TITLE
chore: Add @googleapis/ml-apis to CODEOWNERS for samples directory only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 *                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**  @googleapis/java-samples-reviewers  @googleapis/ml-apis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/cdpe-cloudai is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/cdpe-cloudai
-**/*.java               @googleapis/cdpe-cloudai
+*                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**              @googleapis/java-samples-reviewers @googleapis/cdpe-cloudai

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                       @googleapis/yoshi-java
+# The @googleapis/cdpe-cloudai is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/cdpe-cloudai
+**/*.java               @googleapis/cdpe-cloudai
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 *                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**  @googleapis/java-samples-reviewers  @googleapis/ml-apis
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,6 +13,5 @@
     "api_id": "documentai.googleapis.com",
     "transport": "grpc",
     "requires_billing": true,
-    "library_type": "GAPIC_AUTO",
-    "codeowner_team": "@googleapis/cdpe-cloudai"
+    "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,6 @@
     "api_id": "documentai.googleapis.com",
     "transport": "grpc",
     "requires_billing": true,
-    "library_type": "GAPIC_AUTO"
+    "library_type": "GAPIC_AUTO",
+    "codeowner_team": "@googleapis/cdpe-cloudai"
 }

--- a/owlbot.py
+++ b/owlbot.py
@@ -21,4 +21,9 @@ for library in s.get_staging_dirs():
     s.move(library)
 
 s.remove_staging_dirs()
-java.common_templates()
+java.common_templates(
+    excludes=[
+        # adding CODEOWNERS file to exclude list
+        # because Cloud AI DPE team need access to samples folder only.
+        ".github/CODEOWNERS"
+    ])


### PR DESCRIPTION
This will allow @googleapis/ml-apis to update/add/remove samples without requiring a review from the Yoshi Java team.
