### PR TITLE
chore: update codeowners to include README.md for samples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,6 @@
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**              @googleapis/java-samples-reviewers @googleapis/cdpe-cloudai
+# When new samples are created/removed, links to samples are added/removed
+# to/from README.md by owlbot.py
+README.md               @googleapis/java-samples-reviewers @googleapis/cdpe-cloudai


### PR DESCRIPTION
This PR updates the CODEOWNERS file to account for the fact that when new
samples are added or old samples are removed owlbot.py adds or removes the links
to those samples in README.md. This PR adds README.md ownership to sample
directory owners so that additions and removals of samples can be made without
requiring library-level (currently the group "yoshi-java") approval.

🦉