### PR TITLE
ci: removing clirr from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,6 @@ branchProtectionRules:
       - dependencies (8)
       - dependencies (11)
       - lint
-      - clirr
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -28,7 +27,6 @@ branchProtectionRules:
       - dependencies (8)
       - dependencies (11)
       - lint
-      - clirr
       - units (7)
       - units (8)
       - units (11)

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -8,7 +8,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
       - dependencies (11)
       - lint
       - units (8)
@@ -24,7 +23,6 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - dependencies (8)
       - dependencies (11)
       - lint
       - units (7)

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.0')
 
 implementation 'com.google.cloud:google-cloud-document-ai'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-document-ai:2.6.0'
+implementation 'com.google.cloud:google-cloud-document-ai:2.6.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-document-ai" % "2.6.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-document-ai" % "2.6.2"
 ```
 
 ## Authentication


### PR DESCRIPTION
ci: removing clirr from required checks and duplicate "dependencies" check (Java 8 and Java 11 results are the same)