### PR TITLE
samples: mention the "eu" endpoit when creating the client

### DIFF
--- a/samples/snippets/src/main/java/documentai/v1/QuickStart.java
+++ b/samples/snippets/src/main/java/documentai/v1/QuickStart.java
@@ -47,6 +47,11 @@ public class QuickStart {
     // Initialize client that will be used to send requests. This client only needs to be created
     // once, and can be reused for multiple requests. After completing all of your requests, call
     // the "close" method on the client to safely clean up any remaining background resources.
+    // If location is "eu", use:
+    // DocumentProcessorServiceClient.create(
+    //     DocumentProcessorServiceSettings.newBuilder()
+    //         .setEndpoint("eu-documentai.googleapis.com:443")
+    //         .build()))
     try (DocumentProcessorServiceClient client = DocumentProcessorServiceClient.create()) {
       // The full resource name of the processor, e.g.:
       // projects/project-id/locations/location/processor/processor-id


### PR DESCRIPTION
The endpoint must be set manually if the default location "us" is not used.

See:
https://cloud.google.com/document-ai/docs/regions
https://stackoverflow.com/a/70188611